### PR TITLE
Write metadata to files in background

### DIFF
--- a/exiftool_wrapper.py
+++ b/exiftool_wrapper.py
@@ -104,11 +104,12 @@ class ExifTool(object):
         args.append('-n')
         if type(filenames)==str:
             args.append(filenames)
+            file_to_return=filenames
         else:
             for filename in filenames:
                 args.append(filename)
-
-        return json.loads(self.execute(args))
+        tags_to_return = self.execute((args))
+        return json.loads(tags_to_return)
 
     def setTags(self, filenames, tag_values={}):
         if tag_values=={}:

--- a/memory_mate.py
+++ b/memory_mate.py
@@ -2,6 +2,8 @@ import sys
 from ui_widgets import *
 from PyQt5.QtWidgets import QWidget,QMainWindow,QApplication
 from exiftool_wrapper import ExifTool
+from file_metadata_util import QueueHost
+
 class MainWindow(QMainWindow):
     def __init__(self):
         super().__init__()
@@ -37,6 +39,8 @@ class MainWindow(QMainWindow):
 
         main_widget.setLayout(main_layout)
 
+        # Prepare queue-processor
+
     def closeEvent(self, event):
         FilePanel.saveMetadata()      # Saves metadata if changed
         ExifTool.close()              # Close exiftool process
@@ -50,6 +54,9 @@ font_size = str(font.pointSize())+"pt"
 font_weight = str(font.weight())
 app.setStyleSheet(f"* {{ font-family: {font_family}; font-size: {font_size}; font-weight: {font_weight};}}")
 window = MainWindow()
+QueueHost.get_instance().start_queue_worker(delay=0)    #Start Queue-processing
 window.setGeometry(100, 100, 2000, 1000)
 window.show()
+
 app.exec()
+

--- a/settings.py
+++ b/settings.py
@@ -1,5 +1,6 @@
 import json
 import os
+from file_util import JsonQueue
 #
 # Make location for Application, if missing
 #
@@ -8,6 +9,7 @@ if not os.path.isdir(app_data_location):
     os.mkdir(app_data_location)
 
 settings_path = os.path.join(app_data_location,"settings.json")
+queue_file_path = os.path.join(app_data_location,"queue.json")
 
 #
 # Read settings-file, if it is there

--- a/ui_widgets.py
+++ b/ui_widgets.py
@@ -128,7 +128,7 @@ class FileList(QTreeView):
             self.source=[]
             self.source_is_single_file=False
 
-        if self.source_is_single_file:
+        if self.source_is_single_file and len(self.source) == 1:   #Exactly one field selected
             self.paste_metadata.setEnabled(True)
             self.patch_metadata.setEnabled(True)
             self.paste_by_filename.setEnabled(True)


### PR DESCRIPTION
All writes to metadata is done to a queue-file in stead of updating metadata directly in files. This enables a smoother workflow without waits for the user. The queue-file will survive an app-crash. When starting the app again, the queue-processing will be continued.
When user looks at the file-metadata, she will see the newest, updated data, also if the data is still in the queue, not written to file yet.